### PR TITLE
Fix Account Balance form field

### DIFF
--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -76,7 +76,7 @@
 
         <%= render "accounts/#{permitted_accountable_partial(@account.accountable_type)}", f: f %>
 
-        <%= f.number_field :balance, placeholder: number_to_currency(0), in: 0.00..100000000.00, required: 'required', label: true %>
+        <%= f.number_field :balance, placeholder: number_to_currency(0), in: 0.00..100000000.00, step: '0.01', required: 'required', label: true %>
       </div>
 
       <%= f.submit "Add #{@account.accountable.model_name.human.downcase}" %>


### PR DESCRIPTION
Add a step to the Balance form number_field adjusting the step for currency with two decimal places.
This fixes the constraints some web browsers enforce on number_fields like minimum and maximum values.

Using `step: '0.01'` instead of `step: :any`, adjusting to two decimal places.